### PR TITLE
fix: hide nav brand text on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,6 +445,16 @@ nav.nav-open .nav-toggle span:nth-child(3) {
 }
 
 @media (max-width: 700px) {
+  .nav-brand {
+    font-size: 0;
+    gap: 0;
+    margin-right: 0;
+  }
+
+  .nav-brand .nav-logo {
+    font-size: initial;
+  }
+
   .nav-toggle {
     display: flex;
   }


### PR DESCRIPTION
## Summary
- Hide "Oncology Toolkit" text in the nav bar on mobile viewports (≤700px) using `font-size: 0`
- Logo icon remains visible for brand identification
- Frees horizontal space for the hamburger menu and theme toggle

## Pre-Landing Review
No issues found.

## Test plan
- [x] Verified mobile nav bar shows only logo icon (no text)
- [x] Verified hamburger menu opens correctly with all 6 nav links
- [x] Verified active page highlight works in mobile dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)