### PR TITLE
fix: prevent mobile dropdown menu from hiding behind page content

### DIFF
--- a/style.css
+++ b/style.css
@@ -251,7 +251,7 @@ body::before {
   z-index: 0;
 }
 
-body > *:not(script) {
+body > *:not(script):not(nav) {
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- Fix mobile nav dropdown rendering behind page content (tables, cards, headings)
- Root cause: `body > *:not(script) { z-index: 1 }` had higher CSS specificity than `nav { z-index: 100 }`, overriding the nav's stacking order
- Fix: exclude `nav` from that rule with `:not(nav)`

## Pre-Landing Review
No issues found.

## Test plan
- [x] Mobile dropdown renders above page content on BED page (most content-heavy)
- [x] Mobile dropdown renders above page content on Reirradiation page
- [x] Desktop nav unaffected
- [x] Both dark and light themes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)