### PR TITLE
fix: align BED calculator data columns

### DIFF
--- a/style.css
+++ b/style.css
@@ -1139,6 +1139,7 @@ nav.nav-open .nav-toggle span:nth-child(3) {
   border-collapse: collapse;
   font-size: 14px;
   min-width: 420px;
+  table-layout: fixed;
 }
 
 .bed-table th {
@@ -1151,6 +1152,7 @@ nav.nav-open .nav-toggle span:nth-child(3) {
 .bed-table th:first-child,
 .bed-table td:first-child {
   text-align: left;
+  width: 25%;
 }
 
 .bed-table td {


### PR DESCRIPTION
## Summary
- Add `table-layout: fixed` to `.bed-table` so columns have consistent widths
- Set first column (labels) to 25%, giving the three data columns equal share of remaining space
- Prescription Dose and Alternative Fractionation tables now align vertically

## Test plan
- [x] Visual verification at default and 1280px viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)