### PR TITLE
fix(nav): collapse to hamburger at 900px (stop tablet overflow)

### DIFF
--- a/style.css
+++ b/style.css
@@ -199,7 +199,7 @@
   background: rgba(198, 40, 40, 0.06);
 }
 
-@media (max-width: 700px) {
+@media (max-width: 900px) {
   [data-theme="light"] .nav-link.active {
     border-left-color: var(--accent);
     background: var(--accent-dim);
@@ -240,7 +240,7 @@
 [data-theme="light"] .theme-toggle .icon-sun { display: inline; }
 [data-theme="light"] .theme-toggle .icon-moon { display: none; }
 
-@media (max-width: 700px) {
+@media (max-width: 900px) {
   .theme-toggle {
     margin-left: auto;
     margin-right: 8px;
@@ -472,7 +472,7 @@ nav.nav-open .nav-toggle span:nth-child(3) {
   transform: translateY(-7px) rotate(-45deg);
 }
 
-@media (max-width: 700px) {
+@media (max-width: 900px) {
   .nav-brand {
     font-size: 0;
     gap: 0;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v4-2026-05-22';
+var CACHE_VERSION = 'v5-2026-05-23';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
## Summary
Fixes a pre-existing responsive bug found by `/qa` on production: every page scrolled horizontally between 701px and ~880px (iPad portrait = 768px), with the "Dark" theme toggle clipped off the right edge.

**Root cause:** the desktop nav needs ~876px (7 links + brand + theme toggle) but the hamburger only appeared at `@media (max-width:700px)`. The 701–880px range showed the full inline nav, which overflows.

**Fix:** raise the three nav `@media` blocks from `700px` → `900px` (style.css ~lines 202/243/475) so the menu collapses before it can overflow. The mobile result-table `@media` block stays at `700px` — tables fit fine at 768px in desktop mode. `CACHE_VERSION` bumped v4 → v5.

## Verification
Local at `http://localhost`:
- 768px: overflow=false, hamburger shown ✅
- 880px: overflow=false, hamburger shown ✅
- 1024px: overflow=false, full desktop nav ✅

## Test plan
- [x] No horizontal overflow at 768/880px
- [x] Full desktop nav still renders >900px
- [x] Mobile table transpose/card-stack unaffected (separate @media at 700px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)