### PR TITLE
chore: privacy section + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# macOS
+.DS_Store
+
+# gstack local artifacts (browse logs, QA + design reports) — not site files
+.gstack/
+
+# local reference material (journal PDFs etc.) — not served by the site
+data/

--- a/about.html
+++ b/about.html
@@ -121,6 +121,42 @@
           <a href="mailto:schedulizerbot@gmail.com" class="about-email">schedulizerbot@gmail.com</a>.
         </p>
 
+        <hr class="about-divider">
+
+        <h3>Privacy</h3>
+        <p>
+          Oncology Toolkit collects no personal information, no protected health
+          information (PHI), and no patient data. Calculator inputs are processed
+          entirely in your browser and are never transmitted to a server.
+        </p>
+        <p>
+          The site uses two analytics services to understand aggregate traffic
+          patterns:
+        </p>
+        <ul>
+          <li>
+            <strong>Google Analytics 4</strong> &mdash; sets <code>_ga</code> and
+            <code>_ga_*</code> cookies to count unique visitors and measure page
+            views. IP addresses are truncated by Google before storage. Ad
+            personalization features (Google Signals) are disabled.
+          </li>
+          <li>
+            <strong>Cloudflare Web Analytics</strong> &mdash; cookieless; collects
+            anonymous page-load and performance metrics only.
+          </li>
+        </ul>
+        <p>
+          The site also uses <strong>browser local storage</strong> (not cookies)
+          to remember your theme preference, recent calculator inputs, and cached
+          ICD-10 data for offline use. This data stays on your device and is never
+          sent anywhere. You can clear it at any time through your browser settings.
+        </p>
+        <p>
+          To opt out of Google Analytics, use a browser extension such as the
+          <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener">Google Analytics Opt-out Add-on</a>
+          or enable your browser&rsquo;s tracking-protection / Do Not Track features.
+        </p>
+
       </div>
     </div>
     <script src="shortcuts.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v5-2026-05-23';
+var CACHE_VERSION = 'v6-2026-05-23';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
## Summary
Two housekeeping fixes surfaced after the mobile-responsive work.

1. **about.html — Privacy section** (was an uncommitted local change). Documents that the site collects no personal data/PHI, the two analytics services (GA4 with IP truncation + Signals off; cookieless Cloudflare), local-storage usage (theme/history/offline ICD-10), and how to opt out. Reuses existing `.about-divider` / `.about-card h3/ul` styles — verified rendering with no overflow. `CACHE_VERSION` bumped v5 → v6 (about.html is in `REQUIRED_PRECACHE`).
2. **.gitignore** (repo previously had none). Ignores `.DS_Store`, `.gstack/` (gstack tooling output — browse logs, QA/design reports), and `data/` (a 667KB journal PDF not served by the site). All were sitting untracked in the repo root.

## Test plan
- [x] `git status` clean after .gitignore (cruft no longer tracked)
- [x] about.html Privacy section renders styled, no horizontal overflow (local 900px)
- [x] CACHE_VERSION bumped for the precached about.html change

🤖 Generated with [Claude Code](https://claude.com/claude-code)