### PR TITLE
feat(nav): add OncBrain external link to nav bar

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,6 +41,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link active">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/bed.html
+++ b/bed.html
@@ -42,6 +42,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/composite.html
+++ b/composite.html
@@ -42,6 +42,7 @@
         <a href="composite.html" class="nav-link active">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/constraints.html
+++ b/constraints.html
@@ -42,6 +42,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link active">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/psa.html
+++ b/psa.html
@@ -41,6 +41,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/rert.html
+++ b/rert.html
@@ -42,6 +42,7 @@
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link active">Reirradiation</a>
         <a href="constraints.html" class="nav-link">Dose Constraints</a>
+        <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
       <button class="theme-toggle" id="theme-toggle" aria-label="Switch to light mode">

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v6-2026-05-23';
+var CACHE_VERSION = 'v7-2026-05-29';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
## Summary

Adds a new-tab link to **oncbrain.oncologytoolkit.com** in the nav bar of all 7 pages, positioned between "Dose Constraints" and "About". The `↗` glyph signals it leads off-site; `target="_blank"` + `rel="noopener noreferrer"` is the standard safety pair.

## Files

- `about.html`, `bed.html`, `composite.html`, `constraints.html`, `index.html`, `psa.html`, `rert.html` — nav link added
- `sw.js` — `CACHE_VERSION` bumped `v6-2026-05-23` → `v7-2026-05-29` (every precached HTML changed, per the deploy discipline in CLAUDE.md)

## Notes

- No CSS changes; new link inherits the existing `.nav-link` class and the hamburger-menu collapse behavior.
- No tests or VERSION/CHANGELOG in this repo to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)