### PR TITLE
feat(hub): replace ICD landing with tool-launcher hub + recents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,38 +26,39 @@ Analytics: Google Analytics `G-PP2FRCMYS1` + Cloudflare Web Analytics beacon `90
 
 | Page | Tool | Backing JS |
 |------|------|------------|
-| `index.html` | ICD-10 code search | `script.js` |
+| `index.html` | Hub landing — 2×3 / 3×2 tile grid + recents row (BED + Composite + ReRT) | inline `<script>` in the page; reads `history.js` + `url-state.js` |
 | `bed.html` | BED / EQD2 calculator | `bed.js` + `math.js` |
 | `psa.html` | PSA doubling time | `psa.js` (Chart.js) |
 | `composite.html` | Composite dose (re-tx tolerance) | `composite.js` + `math.js` |
 | `rert.html` | Reirradiation OAR tolerance (UMich ReRT) | `rert.js` + `math.js` |
 | `constraints.html` | QUANTEC/HyTEC/NRG dose constraints | `constraints.js` |
+| `icd.html` | ICD-10 code search | `script.js` (XHR-loads 9 MB `icd10.xml` only on this page) |
 | `about.html` | About / contact | `theme.js` only |
 
-All pages share: nav (hamburger on mobile), theme toggle, site disclaimer footer, both analytics scripts.
+All pages share: nav (hamburger on mobile at ≤900 px), theme toggle, site disclaimer footer, both analytics scripts. The hub doesn't show an `.active` nav link — the brand mark serves as the Home affordance. Six calculator tiles route to the six calc pages; the seven nav links (BED, PSA, Composite, ReRT, Constraints, OncBrain external, About) are reachable from every page including the hub.
 
 ## JS modules
 
 **Shared (loaded by multiple pages):**
 - `math.js` — single source of truth for `calcBED`, `calcEQD2`, `isoeffDose`, `fmt`. Used by bed/composite/rert. **No duplication** — do not re-implement these formulas.
-- `url-state.js` — `parseUrlParams` / `serializeToUrl` for shareable calculator links.
-- `history.js` — localStorage history (10-item dedupe) for calculators.
+- `url-state.js` — `parseUrlParams` / `applyUrlParams` / `serializeToUrl` for shareable calculator links, plus `buildToolUrl(toolPath, params)` for building hub recents URLs from a params object (since `serializeToUrl` reads from the current DOM and is unusable from the hub).
+- `history.js` — localStorage history (10-item dedupe) for calculators. Adds the shared summary functions `bedSummary` / `compositeSummary` / `rertSummary` (single source of truth — `bed.js` / `composite.js` / `rert.js` all call these instead of duplicating inline lambdas), plus `getRecentAcrossTools(limit)` for the hub recents (merges `history_bed` + `history_composite` + `history_rert`, defensively filters malformed entries, sorts ts desc).
 - `theme.js` — dark/light toggle, persists to `localStorage['theme']`, dispatches `'themechange'` event. Inlined in `<head>` to prevent flash.
 - `clipboard.js` — `navigator.clipboard` with `execCommand` fallback.
-- `shortcuts.js` — `/` or `Ctrl+K` to focus first input, `Esc` to blur.
+- `shortcuts.js` — `/` or `Ctrl+K` to focus first input, `Esc` to blur. No-ops gracefully on the hub (no inputs).
 
 **Page-specific:**
-- `script.js` — XHR-loads `icd10.xml`, AND-match search, 100-result cap, click-to-copy.
-- `bed.js` — preset regimens, validation ranges (`BED_RANGES`), update() pattern.
+- `script.js` — XHR-loads `icd10.xml`, AND-match search, 100-result cap, click-to-copy. Loaded **only** by `icd.html` (never by the hub at `/`).
+- `bed.js` — preset regimens, validation ranges (`BED_RANGES`), update() pattern. History label uses the shared `bedSummary` from `history.js`.
 - `psa.js` — weighted least-squares exponential fit (weights `w = y²`), 95% CI bands, click-to-query.
-- `composite.js` — tolerance BED − (prior BED × TDF), warns if prior > tolerance.
-- `rert.js` — biggest file (~500 lines). `OAR_DATA` const = 24 OARs (22 serial + 2 parallel). TRF auto-highlights based on months since prior RT.
+- `composite.js` — tolerance BED − (prior BED × TDF), warns if prior > tolerance. History label uses the shared `compositeSummary` from `history.js`.
+- `rert.js` — biggest file (~500 lines). `OAR_DATA` const = 24 OARs (22 serial + 2 parallel). TRF auto-highlights based on months since prior RT. Plan-level inputs (`pr-fx`, `pr-ab`, `pr-mo`, `custom-fx`) save to `history_rert` on `change` and render via shared `rertSummary`. OAR selection is not in `RERT_INPUT_IDS` — recents restore the numerics, user re-ticks OARs.
 - `constraints.js` — fetches `constraints-data.json`, AND-match search, source filter, PubMed links.
-- `tests.js` — test suite.
+- `tests.js` — test suite. Run with `node tests.js` (no test framework, no build — vanilla DOM-shimmed `node:vm` sandbox). Currently 271 assertions, 0 failures.
 
 ## CSS
 
-Single `style.css` (~47 KB) with numbered TOC at top (sections 1–20). Theming via CSS variables under `:root` and `[data-theme="light"]`. Dark is default. Accent: `#4fc3f7` (dark) / `#0288d1` (light).
+Single `style.css` (~50 KB) with numbered TOC at top (sections 1–21). Theming via CSS variables under `:root` and `[data-theme="light"]`. Dark is default. Accent: `#4fc3f7` (dark) / `#0288d1` (light). Section 21 is the hub landing (`.hub-container` / `.hub-grid` / `.hub-tile` / `.hub-recents` / `.hub-recent-pill`). `.hub-tile` uses class composition (`<a class="bed-card hub-tile">`) so it inherits `.bed-card` chrome and only contains hub-specific deltas. **Mobile breakpoint convention: `@media (max-width: 900px)`** to match the nav hamburger; new responsive sections must use this same breakpoint so nav and content switch to mobile mode together.
 
 When adding styles, find the right numbered section and add there — don't append to the bottom.
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,12 @@ A collection of clinical calculation and reference tools for radiation oncology,
 
 ## Tools
 
-### ICD-10 Code Search
-Fast full-text search of ICD-10 diagnostic codes with oncology-focused filters.
-- Filter by All, Malignancy, In Situ, Benign Neoplasm, or Z Code
-- Click any **code** to copy it to the clipboard
-- Click the **⧉ button** on any diagnosis to copy the full text
-- ICD-10 data stored locally — no API calls, instant results
-
-### PSA Doubling Time Calculator
-Calculates PSA doubling time from serial PSA measurements using weighted least-squares exponential fitting (weights w = y²).
-- Flexible date parsing — accepts most common date formats (MM/DD/YYYY, YYYY-MM-DD, DD.MM.YYYY, etc.)
-- Interactive Chart.js plot projected forward with configurable years
-- 95% confidence interval bands on the fit curve
-- Click anywhere on the chart to query the expected PSA at that date
-- White background toggle for pasting into documents
-- Copy Results button — composites the doubling time, chart, and measurement table as a PNG to the clipboard
-- Chart automatically adapts to light/dark mode
+The landing page is a **hub**: a 6-tile launcher (BED, ReRT, Composite, Constraints, PSA, ICD Search) above a "Recent calculations" row that one-click reopens your last calcs on BED, Composite, or ReRT. Six calculator tiles below it route to the tools described in this section.
 
 ### BED / EQD2 Calculator
 Computes Biologically Effective Dose (BED) and Equivalent Dose in 2 Gy fractions (EQD2) for a given prescription.
 - Configurable α/β values for Tumor (10), Late tissue (3), and Prostate/Spine (2)
 - Alternative fractionation section: converts the same BED to isoeffective total doses for 1, 3, 5, and an arbitrary number of fractions
-- Based on a spreadsheet by Dr. Mike Wahl
-
-### Composite Dose Calculator
-Estimates the remaining tolerable dose to a previously irradiated structure.
-- Inputs: structure tolerance dose/fractions/α/β, prior dose, time discount factor, planned fractions
-- Outputs: remaining BED and safe physical dose per fraction
 - Based on a spreadsheet by Dr. Mike Wahl
 
 ### Reirradiation Dose Calculator
@@ -46,12 +25,43 @@ Estimates remaining organ-at-risk dose tolerance for reirradiation using Univers
 - Parallel OARs (Lungs V16, Liver V32) use volumetric cc inputs with remaining cc output
 - All values update in real time as inputs change
 
+### Composite Dose Calculator
+Estimates the remaining tolerable dose to a previously irradiated structure.
+- Inputs: structure tolerance dose/fractions/α/β, prior dose, time discount factor, planned fractions
+- Outputs: remaining BED and safe physical dose per fraction
+- Based on a spreadsheet by Dr. Mike Wahl
+
+### Dose Constraint Reference
+QUANTEC, HyTEC, and ASTRO 2026 (Puckett) DVH constraints with PubMed-linked citations.
+- AND-match search across organ, endpoint, dose, and source
+- Filter by source compendium
+- Click any constraint to copy the full citation
+
+### PSA Doubling Time Calculator
+Calculates PSA doubling time from serial PSA measurements using weighted least-squares exponential fitting (weights w = y²).
+- Flexible date parsing — accepts most common date formats (MM/DD/YYYY, YYYY-MM-DD, DD.MM.YYYY, etc.)
+- Interactive Chart.js plot projected forward with configurable years
+- 95% confidence interval bands on the fit curve
+- Click anywhere on the chart to query the expected PSA at that date
+- White background toggle for pasting into documents
+- Copy Results button — composites the doubling time, chart, and measurement table as a PNG to the clipboard
+- Chart automatically adapts to light/dark mode
+
+### ICD-10 Code Search
+Fast full-text search of ICD-10 diagnostic codes with oncology-focused filters.
+- Filter by All, Malignancy, In Situ, Benign Neoplasm, or Z Code
+- Click any **code** to copy it to the clipboard
+- Click the **⧉ button** on any diagnosis to copy the full text
+- ICD-10 data stored locally — no API calls, instant results
+- Loads the 9 MB ICD-10 XML only when you open this page (not from the hub)
+
 ---
 
 ## Features
 
 - **Installable PWA** — install to your home screen or desktop; runs in standalone mode with iOS safe-area handling for the iPhone notch
-- **Works offline** — service worker precaches the app shell, so calculators (BED, Composite, ReRT, Constraints, PSA) work without network. ICD-10 search caches lazily on first online use.
+- **Works offline** — service worker precaches the app shell, so the hub and calculators (BED, Composite, ReRT, Constraints, PSA) work without network. ICD-10 search caches lazily on first online use.
+- **Recents on the hub** — returning users see their last 1–3 calculations on BED, Composite, or ReRT as one-click pills above the tile grid. Stored only in your browser's localStorage.
 - **Dark / Light mode** — toggle in the nav bar, preference saved per visitor via localStorage
 - **Responsive design** — works on desktop and mobile with collapsible hamburger navigation
 - **No account required** — all calculations run client-side in the browser

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,19 +4,19 @@ Tracking open work and ideas for future improvement.
 
 ## Open
 
-### Test runner is broken
-**Priority:** P1
-**Component:** tests.js
-**Discovered:** 2026-05-08 (during PWA ship)
-
-`tests.js` runs source files inside a `node:vm` context that has no `document`. Three calculator files (`bed.js:120`, `composite.js:158`, `rert.js:565`) execute `document.addEventListener('decimalschange', ...)` at top level (added with the decimals feature in commit `14c25b6`), so the runner crashes with `TypeError: document.addEventListener is not a function` before any assertion runs. Fix: either provide a JSDOM-style `document` shim in `tests.js`, or wrap the top-level event bindings in a guard so they only run when `typeof document !== 'undefined'`.
-
 ### Automate CACHE_VERSION bump
 **Priority:** P2
 **Component:** sw.js, deploy workflow
 **Discovered:** 2026-05-08
 
 `sw.js` requires manual `CACHE_VERSION` bump on every deploy that changes a precached file. Forgetting it ships fresh HTML against stale cached JS until the next bump. Options: pre-commit hook that bumps if any precached file is staged; GitHub Actions step that derives the version from the latest git SHA; or a tiny build step that hashes precache file contents.
+
+### Formalize design system as DESIGN.md
+**Priority:** P2
+**Component:** docs, style.css
+**Discovered:** 2026-05-30 (during /plan-design-review for the tool-hub landing)
+
+The de facto design system lives implicitly in `style.css` (CSS variables under `:root` + `[data-theme="light"]`, DM Sans body / Outfit display, `.bed-card` token, radius scale, transition scale, accent `#4fc3f7` / `#0288d1`). Future `/plan-design-review` runs would calibrate more consistently against a real `DESIGN.md`. Run `/design-consultation` to inventory tokens, document the type scale, document component vocabulary, and add usage rules (e.g., "tile cards use class composition with `.bed-card`; new `.foo-*` class families should match the breakpoint convention of 900 px nav-hamburger + 700 px content stack").
 
 ## Completed (2026-03-16)
 

--- a/about.html
+++ b/about.html
@@ -35,7 +35,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>

--- a/bed.html
+++ b/bed.html
@@ -36,7 +36,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link active">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>

--- a/bed.js
+++ b/bed.js
@@ -85,9 +85,9 @@ function update() {
   // Save to history on valid calculation
   if (valid) {
     saveToHistory('bed', BED_INPUT_IDS);
-    renderHistory('bed', BED_INPUT_IDS, update, function (params) {
-      return (params['bd-dose'] || '?') + ' Gy / ' + (params['bd-fx'] || '?') + ' fx';
-    });
+    // bedSummary is defined in history.js — single source of truth so the
+    // per-page history list and the hub's recents pill render identical text.
+    renderHistory('bed', BED_INPUT_IDS, update, bedSummary);
   }
 }
 

--- a/composite.html
+++ b/composite.html
@@ -36,7 +36,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link active">Composite Dose</a>

--- a/composite.js
+++ b/composite.js
@@ -140,9 +140,8 @@ function update() {
   // Save to history
   if (stBedValid && pvBedValid) {
     saveToHistory('composite', COMP_INPUT_IDS);
-    renderHistory('composite', COMP_INPUT_IDS, update, function (params) {
-      return 'Tol ' + (params['st-dose'] || '?') + 'Gy, Prior ' + (params['pv-dose'] || '?') + 'Gy';
-    });
+    // compositeSummary is defined in history.js — single source of truth.
+    renderHistory('composite', COMP_INPUT_IDS, update, compositeSummary);
   }
 }
 

--- a/history.js
+++ b/history.js
@@ -96,3 +96,55 @@ function defaultHistorySummary(params) {
   });
   return parts.join(' / ');
 }
+
+// ------------------------------------------------------------------
+// Per-tool summary functions — single source of truth.
+// bed.js, composite.js, rert.js all call these (instead of inline lambdas)
+// so the per-page history list and the hub's recents pills render the
+// identical text for any given entry.
+// ------------------------------------------------------------------
+
+function bedSummary(p) {
+  return (p['bd-dose'] || '?') + ' Gy / ' + (p['bd-fx'] || '?') + ' fx';
+}
+
+function compositeSummary(p) {
+  return 'Tol ' + (p['st-dose'] || '?') + 'Gy, Prior ' + (p['pv-dose'] || '?') + 'Gy';
+}
+
+function rertSummary(p) {
+  // Note: OAR selection is not in RERT_INPUT_IDS, so the pill label can't
+  // include which organs were checked. Partial-state restore by design.
+  return 'prior ' + (p['pr-fx'] || '?') + ' fx, ' + (p['pr-mo'] || '?') + ' mo ago';
+}
+
+// ------------------------------------------------------------------
+// Cross-tool recents — used by the hub landing page (index.html).
+// Reads localStorage for each known tool, merges, sorts by ts desc,
+// slices to `limit`. Defensively filters entries missing `ts` or
+// `params` (hand-edited localStorage, future schema drift).
+// ------------------------------------------------------------------
+
+var KNOWN_TOOLS = [
+  { tool: 'bed',       path: 'bed.html',       label: bedSummary },
+  { tool: 'composite', path: 'composite.html', label: compositeSummary },
+  { tool: 'rert',      path: 'rert.html',      label: rertSummary }
+];
+
+function getRecentAcrossTools(limit) {
+  var all = [];
+  KNOWN_TOOLS.forEach(function (t) {
+    loadHistoryRaw('history_' + t.tool).forEach(function (entry) {
+      if (typeof entry.ts !== 'number' || !entry.params) return;
+      all.push({
+        tool: t.tool,
+        ts: entry.ts,
+        params: entry.params,
+        path: t.path,
+        label: t.label(entry.params)
+      });
+    });
+  });
+  all.sort(function (a, b) { return b.ts - a.ts; });
+  return all.slice(0, limit || 3);
+}

--- a/icd.html
+++ b/icd.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>Dose Constraints – Oncology Toolkit</title>
+    <title>ICD-10 Code Search – Oncology Toolkit</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="icon" href="favicon-32.png" sizes="32x32" type="image/png">
@@ -36,12 +36,12 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="icd.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link active">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>
         <a href="rert.html" class="nav-link">Reirradiation</a>
-        <a href="constraints.html" class="nav-link active">Dose Constraints</a>
+        <a href="constraints.html" class="nav-link">Dose Constraints</a>
         <a href="https://oncbrain.oncologytoolkit.com" class="nav-link" target="_blank" rel="noopener noreferrer">OncBrain &#8599;</a>
         <a href="about.html" class="nav-link">About</a>
       </div>
@@ -51,59 +51,36 @@
       </button>
     </nav>
 
-    <div class="bed-container constraints-container">
+    <div class="bed-container">
       <div class="bed-card">
-        <div class="constraint-search-row">
-          <input type="text" id="constraintSearch" placeholder="Search by organ, endpoint, or keyword…" autocomplete="off">
-          <select id="sourceFilter" class="constraint-source-select">
-            <option value="all">All Sources</option>
-            <option value="quantec">QUANTEC</option>
-            <option value="hytec">HyTEC</option>
-            <option value="astro dvh">ASTRO DVH Compendium (Puckett 2026)</option>
-            <optgroup label="NRG Protocols">
-              <option value="nrg-gi011">NRG-GI011 (Pancreas)</option>
-              <option value="nrg gu-005">NRG GU-005 (Prostate)</option>
-              <option value="nrg gu-009">NRG GU-009 (Prostate)</option>
-              <option value="nrg gu-010">NRG GU-010 (Prostate)</option>
-              <option value="nrg gu-013">NRG GU-013 (Prostate)</option>
-              <option value="nrg lu-008">NRG LU-008 (Lung)</option>
-              <option value="nrg hn-009">NRG HN-009 (Head & Neck)</option>
-              <option value="nrg br-008">NRG BR-008 (Breast)</option>
-            </optgroup>
-            <optgroup label="Other Protocols">
-              <option value="tailor-rt">TAILOR-RT (Breast)</option>
-              <option value="embrace-ii">EMBRACE-II (Cervix)</option>
-            </optgroup>
-          </select>
-        </div>
-        <div class="constraint-meta-row">
-          <span id="resultCount" class="constraint-result-count"></span>
+        <input type="text" id="searchTerm" placeholder="Search diagnoses…" autocomplete="off">
+        <div class="checkbox-container">
+          <input type="radio" name="type" id="all">
+          <label for="all">All</label>
+          <input type="radio" name="type" id="selectMalignant" checked>
+          <label for="selectMalignant">Malignancy</label>
+          <input type="radio" name="type" id="selectInSitu">
+          <label for="selectInSitu">In Situ</label>
+          <input type="radio" name="type" id="selectBenign">
+          <label for="selectBenign">Benign Neoplasm</label>
+          <input type="radio" name="type" id="selectZ">
+          <label for="selectZ">Z Code</label>
         </div>
       </div>
 
-      <div id="constraintLoading" class="loading-indicator">Loading constraint data</div>
+      <div id="loadingIndicator" class="loading-indicator">Loading diagnosis codes</div>
 
-      <div id="constraintResults">
-        <div class="bed-table-wrap">
-          <table id="constraintsTable" class="bed-table constraints-table">
-            <thead>
-              <tr>
-                <th>Organ</th>
-                <th>Constraint</th>
-                <th>Endpoint</th>
-                <th>Rate</th>
-                <th>Fractionation</th>
-                <th>Source</th>
-                <th>Citation</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
+      <div id="results">
+        <table id="codesTable">
+          <tr>
+            <th>Code</th>
+            <th>Diagnosis</th>
+          </tr>
+        </table>
       </div>
     </div>
-
-    <script src="constraints.js"></script>
+    <script src="clipboard.js"></script>
+    <script src="script.js"></script>
     <script src="shortcuts.js"></script>
     <script src="theme.js"></script>
     <footer class="site-disclaimer">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>ICD-10 Code Search – Oncology Toolkit</title>
+    <title>Oncology Toolkit</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="icon" href="favicon-32.png" sizes="32x32" type="image/png">
@@ -36,7 +36,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link active">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>
@@ -51,38 +51,83 @@
       </button>
     </nav>
 
-    <div class="bed-container">
-      <div class="bed-card">
-        <input type="text" id="searchTerm" placeholder="Search diagnoses…" autocomplete="off">
-        <div class="checkbox-container">
-          <input type="radio" name="type" id="all">
-          <label for="all">All</label>
-          <input type="radio" name="type" id="selectMalignant" checked>
-          <label for="selectMalignant">Malignancy</label>
-          <input type="radio" name="type" id="selectInSitu">
-          <label for="selectInSitu">In Situ</label>
-          <input type="radio" name="type" id="selectBenign">
-          <label for="selectBenign">Benign Neoplasm</label>
-          <input type="radio" name="type" id="selectZ">
-          <label for="selectZ">Z Code</label>
-        </div>
-      </div>
+    <main class="hub-container">
 
-      <div id="loadingIndicator" class="loading-indicator">Loading diagnosis codes</div>
+      <!-- Recents row — populated by inline script below; entire <section>
+           is removed from the DOM if there are no entries. -->
+      <section class="hub-recents" id="hub-recents" hidden>
+        <h2 class="bed-card-header bed-card-header--standalone">Recent calculations</h2>
+        <div class="hub-recents-row" id="hub-recents-row"></div>
+      </section>
 
-      <div id="results">
-        <table id="codesTable">
-          <tr>
-            <th>Code</th>
-            <th>Diagnosis</th>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <script src="clipboard.js"></script>
-    <script src="script.js"></script>
+      <!-- Tool tiles — class composition: .bed-card provides the card chrome,
+           .hub-tile adds the grid sizing + link styling deltas. -->
+      <section class="hub-grid">
+        <a class="bed-card hub-tile" href="bed.html">
+          <h3 class="hub-tile-name">BED</h3>
+          <p class="hub-tile-tagline">BED &amp; EQD2 conversion</p>
+        </a>
+        <a class="bed-card hub-tile" href="rert.html">
+          <h3 class="hub-tile-name">ReRT</h3>
+          <p class="hub-tile-tagline">Reirradiation OAR tolerance</p>
+        </a>
+        <a class="bed-card hub-tile" href="composite.html">
+          <h3 class="hub-tile-name">Composite</h3>
+          <p class="hub-tile-tagline">Composite dose, re-treatment</p>
+        </a>
+        <a class="bed-card hub-tile" href="constraints.html">
+          <h3 class="hub-tile-name">Constraints</h3>
+          <p class="hub-tile-tagline">QUANTEC / HyTEC / ASTRO 2026</p>
+        </a>
+        <a class="bed-card hub-tile" href="psa.html">
+          <h3 class="hub-tile-name">PSA</h3>
+          <p class="hub-tile-tagline">PSA doubling time</p>
+        </a>
+        <a class="bed-card hub-tile" href="icd.html">
+          <h3 class="hub-tile-name">ICD Search</h3>
+          <p class="hub-tile-tagline">ICD-10 code lookup</p>
+        </a>
+      </section>
+
+    </main>
+
+    <script src="url-state.js"></script>
+    <script src="history.js"></script>
     <script src="shortcuts.js"></script>
     <script src="theme.js"></script>
+    <script>
+      // Hub recents — render up to 3 most-recent calcs across BED + Composite + ReRT.
+      // typeof guard: if history.js somehow failed to load, recents stays hidden
+      // and the tile grid is unaffected (no console error).
+      (function () {
+        if (typeof getRecentAcrossTools !== 'function' || typeof buildToolUrl !== 'function') return;
+        var recents = getRecentAcrossTools(3);
+        if (!recents.length) return;
+        var section = document.getElementById('hub-recents');
+        var row = document.getElementById('hub-recents-row');
+        if (!section || !row) return;
+        recents.forEach(function (r) {
+          var a = document.createElement('a');
+          a.className = 'hub-recent-pill';
+          a.href = buildToolUrl(r.path, r.params);
+          var tool = document.createElement('span');
+          tool.className = 'hub-recent-tool';
+          tool.textContent = r.tool;
+          var dot = document.createElement('span');
+          dot.className = 'hub-recent-divider';
+          dot.textContent = '·';
+          var sum = document.createElement('span');
+          sum.className = 'hub-recent-summary';
+          sum.textContent = r.label;
+          a.appendChild(tool);
+          a.appendChild(dot);
+          a.appendChild(sum);
+          row.appendChild(a);
+        });
+        section.hidden = false;
+      })();
+    </script>
+
     <footer class="site-disclaimer">
       These tools are for educational purposes only and are not a substitute for professional medical advice, diagnosis, or treatment. Always consult a qualified healthcare provider.
     </footer>

--- a/psa.html
+++ b/psa.html
@@ -35,7 +35,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link active">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>

--- a/rert.html
+++ b/rert.html
@@ -36,7 +36,7 @@
         <span></span><span></span><span></span>
       </button>
       <div class="nav-links">
-        <a href="index.html" class="nav-link">ICD-10 Search</a>
+        <a href="icd.html" class="nav-link">ICD-10 Search</a>
         <a href="psa.html" class="nav-link">PSA Doubling Time</a>
         <a href="bed.html" class="nav-link">BED</a>
         <a href="composite.html" class="nav-link">Composite Dose</a>
@@ -155,6 +155,14 @@
           <div class="copy-link-row">
             <button class="psa-action-btn" id="copy-link-btn">Copy Link</button>
           </div>
+
+          <!-- History — plan-level inputs only; OAR selection isn't in RERT_INPUT_IDS,
+               so a recalled entry restores Fractions/α/β/Months but the user re-ticks OARs. -->
+          <details class="bed-card history-section" id="history-section" style="display:none;">
+            <summary class="history-summary">Recent Calculations</summary>
+            <div class="history-list"></div>
+            <button class="history-clear">Clear History</button>
+          </details>
         </div><!-- end .rert-right -->
 
       </div><!-- end .rert-layout -->

--- a/rert.js
+++ b/rert.js
@@ -566,3 +566,27 @@ document.addEventListener('decimalschange', updateAll);
 
 toggleEmptyRow();
 updateAll();
+
+// ============================================================
+// History — save plan inputs (Fractions / α/β / Months / Custom fx)
+// after every input change. saveToHistory dedupes identical entries,
+// so transient keystrokes coalesce into one row per distinct param set.
+// OAR selection is intentionally NOT in RERT_INPUT_IDS — see history.js
+// rertSummary comment and the design doc's Premises section.
+// ============================================================
+
+function saveAndRenderHistory() {
+  var prFx   = parseFloat($('pr-fx').value);
+  var prAb   = parseFloat($('pr-ab').value);
+  var prMo   = parseFloat($('pr-mo').value);
+  if (!isNaN(prFx) && !isNaN(prAb) && !isNaN(prMo)) {
+    saveToHistory('rert', RERT_INPUT_IDS);
+  }
+  // rertSummary is defined in history.js — single source of truth.
+  renderHistory('rert', RERT_INPUT_IDS, updateAll, rertSummary);
+}
+
+RERT_INPUT_IDS.forEach(function (id) {
+  $(id).addEventListener('change', saveAndRenderHistory);
+});
+saveAndRenderHistory();

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@
    18. Loading & Errors ........... Spinners, error states
    19. Footer ..................... Site disclaimer
    20. Print ...................... @media print styles
+   21. Hub Landing ................ index.html tool launcher (recents + tile grid)
    ======================================================================= */
 
 /* -----------------------------------------------------------------------
@@ -43,7 +44,9 @@
   --accent-dim: rgba(79, 195, 247, 0.08);
   --accent-hover: #7dd6fa;
   --text-primary: #ececf0;
-  --text-secondary: #a0a0a8;
+  /* --text-secondary bumped from #a0a0a8 to #b0b0b8 on 2026-05-30 to bring
+     13px body text on --bg-card from ~4.4:1 to ~5.0:1 contrast (WCAG AA). */
+  --text-secondary: #b0b0b8;
   --text-tertiary: #68686e;
   --text-muted: #4a4a50;
   --success: #81c784;
@@ -2412,6 +2415,126 @@ details[open].rert-oar-picker .rert-picker-chevron {
     #rert-empty-row td { display: block; text-align: center; }
     #rert-empty-row td::before { content: ""; }
   }
+}
+
+/* -----------------------------------------------------------------------
+   21. Hub Landing — tool launcher at index.html
+   -----------------------------------------------------------------------
+   The hub uses class composition: tile elements are <a class="bed-card hub-tile">
+   so they inherit .bed-card background/border/shadow/hover. Only hub-specific
+   deltas live here. Mobile breakpoint is 900px to match the nav hamburger
+   (see commit 0347787 / [nav-hamburger-breakpoint-too-low] learning) so the
+   nav and grid switch to mobile mode in lockstep.
+----------------------------------------------------------------------- */
+
+.hub-container {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  animation: fadeInUp 0.4s ease both;
+}
+
+/* Recents row above the tile grid. Hidden by hub.js when no entries. */
+.hub-recents {
+  margin-bottom: 28px;
+}
+
+/* Modifier on .bed-card-header used standalone (no surrounding card).
+   Zeros the border-bottom so the heading floats above the pill row. */
+.bed-card-header--standalone {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 12px;
+}
+
+.hub-recents-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hub-recent-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  text-decoration: none;
+  transition: border-color var(--transition-med), background var(--transition-med);
+  cursor: pointer;
+}
+.hub-recent-pill:hover { border-color: var(--accent); background: var(--bg-card-hover); }
+.hub-recent-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.hub-recent-tool {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.hub-recent-divider { color: var(--text-tertiary); }
+.hub-recent-summary {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+/* Tile grid: 3-col on desktop, 2-col on mobile (≤900px). */
+.hub-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+/* .hub-tile is composed with .bed-card. Only deltas live here:
+   block display so the whole <a> is the tap target, padding override,
+   min-height for visual rhythm, text-decoration none on the link,
+   and hover/focus deltas that lift the card. */
+.hub-tile {
+  display: block;
+  padding: 22px 24px;
+  min-height: 100px;
+  text-decoration: none;
+  /* class composition: background/border/radius/shadow from .bed-card */
+}
+.hub-tile:hover {
+  border-color: var(--border-medium);
+  box-shadow: var(--shadow-card), 0 0 0 1px var(--accent-dim);
+  transform: translateY(-1px);
+}
+.hub-tile:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.hub-tile-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 22px;
+  color: var(--text-primary);
+  line-height: 1.1;
+  margin: 0 0 6px;
+}
+.hub-tile-tagline {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* Mobile (≤900px) — match nav hamburger breakpoint.
+   Pills get 12×16 padding to reach 44px tap target (FINDING-001 standard). */
+@media (max-width: 900px) {
+  .hub-container { padding: 20px 16px 36px; }
+  .hub-grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .hub-tile { padding: 18px 18px; min-height: 88px; }
+  .hub-tile-name { font-size: 19px; }
+  .hub-tile-tagline { font-size: 12px; }
+  .hub-recents { margin-bottom: 22px; }
+  .hub-recent-pill { padding: 12px 16px; }
 }
 
 @media print {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v7-2026-05-29';
+var CACHE_VERSION = 'v8-2026-05-30';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.
@@ -15,6 +15,7 @@ var DATA_CACHE = 'ot-data-v1';
 var REQUIRED_PRECACHE = [
   '/',
   '/index.html',
+  '/icd.html',
   '/bed.html',
   '/psa.html',
   '/composite.html',

--- a/tests.js
+++ b/tests.js
@@ -185,9 +185,14 @@ var tValue95 = sandbox.tValue95;
 var fmtDoublingTime = sandbox.fmtDoublingTime;
 var parseUrlParams = sandbox.parseUrlParams;
 var serializeToUrl = sandbox.serializeToUrl;
+var buildToolUrl = sandbox.buildToolUrl;
 var saveToHistory = sandbox.saveToHistory;
 var loadHistory = sandbox.loadHistory;
 var clearHistory = sandbox.clearHistory;
+var getRecentAcrossTools = sandbox.getRecentAcrossTools;
+var bedSummary = sandbox.bedSummary;
+var compositeSummary = sandbox.compositeSummary;
+var rertSummary = sandbox.rertSummary;
 var copyToClipboard = sandbox.copyToClipboard;
 var HISTORY_MAX = sandbox.HISTORY_MAX;
 
@@ -723,6 +728,139 @@ assertEqual(hist.length, 0, 'history: corrupted JSON returns empty array');
 // Restore
 sandbox.localStorage.clear();
 sandbox.document.getElementById = function() { return makeDomElement(); };
+
+// ============================================================
+// TESTS: url-state.js — buildToolUrl (used by the hub recents)
+// ============================================================
+
+section('=== url-state.js: buildToolUrl ===');
+
+// Empty params → bare path (no trailing ?)
+assertEqual(buildToolUrl.call(sandbox, 'bed.html', {}), 'bed.html',
+  'buildToolUrl: empty params yields bare path');
+
+// Typical use
+var btUrl = buildToolUrl.call(sandbox, 'bed.html', { 'bd-dose': 60, 'bd-fx': 30 });
+assert(btUrl.indexOf('bd-dose=60') !== -1, 'buildToolUrl: bd-dose=60 present');
+assert(btUrl.indexOf('bd-fx=30') !== -1, 'buildToolUrl: bd-fx=30 present');
+assert(btUrl.indexOf('bed.html?') === 0, 'buildToolUrl: starts with toolPath?');
+
+// Empty-string / null / undefined values are skipped (matches serializeToUrl)
+var btSkip = buildToolUrl.call(sandbox, 'bed.html', {
+  'bd-dose': 60, 'bd-fx': '', 'ab1': null, 'ab2': undefined
+});
+assert(btSkip.indexOf('bd-dose=60') !== -1, 'buildToolUrl: kept bd-dose=60');
+assert(btSkip.indexOf('bd-fx') === -1, 'buildToolUrl: empty-string skipped');
+assert(btSkip.indexOf('ab1') === -1, 'buildToolUrl: null skipped');
+assert(btSkip.indexOf('ab2') === -1, 'buildToolUrl: undefined skipped');
+
+// Round-trip: build URL → parse it back → params match
+var rtParams = { 'bd-dose': 70, 'bd-fx': 35, 'ab1': 10, 'ab2': 3 };
+var rtUrl = buildToolUrl.call(sandbox, 'bed.html', rtParams);
+// parseUrlParams reads window.location.search, so we simulate it:
+sandbox.window.location.search = rtUrl.substring(rtUrl.indexOf('?'));
+var rtParsed = parseUrlParams.call(sandbox, ['bd-dose', 'bd-fx', 'ab1', 'ab2']);
+assertEqual(rtParsed['bd-dose'], 70, 'buildToolUrl round-trip: bd-dose=70 recovered');
+assertEqual(rtParsed['bd-fx'], 35,  'buildToolUrl round-trip: bd-fx=35 recovered');
+assertEqual(rtParsed['ab1'], 10,    'buildToolUrl round-trip: ab1=10 recovered');
+assertEqual(rtParsed['ab2'], 3,     'buildToolUrl round-trip: ab2=3 recovered');
+sandbox.window.location.search = ''; // restore
+
+// ============================================================
+// TESTS: history.js — per-tool summary functions
+// ============================================================
+
+section('=== history.js: bedSummary ===');
+assertEqual(bedSummary({ 'bd-dose': '60', 'bd-fx': '30' }), '60 Gy / 30 fx',
+  'bedSummary: both fields present');
+assertEqual(bedSummary({ 'bd-fx': '30' }), '? Gy / 30 fx',
+  'bedSummary: missing bd-dose → ?');
+assertEqual(bedSummary({ 'bd-dose': '60' }), '60 Gy / ? fx',
+  'bedSummary: missing bd-fx → ?');
+assertEqual(bedSummary({}), '? Gy / ? fx',
+  'bedSummary: empty params → ? / ?');
+
+section('=== history.js: compositeSummary ===');
+assertEqual(compositeSummary({ 'st-dose': '50', 'pv-dose': '60' }),
+  'Tol 50Gy, Prior 60Gy', 'compositeSummary: both fields present');
+assertEqual(compositeSummary({ 'pv-dose': '60' }),
+  'Tol ?Gy, Prior 60Gy', 'compositeSummary: missing st-dose');
+assertEqual(compositeSummary({ 'st-dose': '50' }),
+  'Tol 50Gy, Prior ?Gy', 'compositeSummary: missing pv-dose');
+assertEqual(compositeSummary({}),
+  'Tol ?Gy, Prior ?Gy', 'compositeSummary: empty params');
+
+section('=== history.js: rertSummary ===');
+assertEqual(rertSummary({ 'pr-fx': '25', 'pr-mo': '18' }),
+  'prior 25 fx, 18 mo ago', 'rertSummary: both fields present');
+assertEqual(rertSummary({ 'pr-mo': '18' }),
+  'prior ? fx, 18 mo ago', 'rertSummary: missing pr-fx');
+assertEqual(rertSummary({ 'pr-fx': '25' }),
+  'prior 25 fx, ? mo ago', 'rertSummary: missing pr-mo');
+assertEqual(rertSummary({}),
+  'prior ? fx, ? mo ago', 'rertSummary: empty params');
+
+// ============================================================
+// TESTS: history.js — getRecentAcrossTools (hub recents)
+// ============================================================
+
+section('=== history.js: getRecentAcrossTools ===');
+
+// Empty localStorage → empty array
+sandbox.localStorage.clear();
+var recents0 = getRecentAcrossTools.call(sandbox, 3);
+assertEqual(recents0.length, 0, 'getRecentAcrossTools: empty localStorage → []');
+
+// Only BED has entries — only BED returned, tagged correctly
+sandbox.localStorage.setItem('history_bed', JSON.stringify([
+  { ts: 2000, params: { 'bd-dose': '60', 'bd-fx': '30' } },
+  { ts: 1000, params: { 'bd-dose': '70', 'bd-fx': '35' } }
+]));
+var recentsBed = getRecentAcrossTools.call(sandbox, 3);
+assertEqual(recentsBed.length, 2, 'getRecentAcrossTools: BED-only → 2 entries');
+assertEqual(recentsBed[0].tool, 'bed', 'getRecentAcrossTools: entry tagged tool=bed');
+assertEqual(recentsBed[0].path, 'bed.html', 'getRecentAcrossTools: entry tagged path=bed.html');
+assertEqual(recentsBed[0].ts, 2000, 'getRecentAcrossTools: newest first (ts=2000)');
+assertEqual(recentsBed[0].label, '60 Gy / 30 fx', 'getRecentAcrossTools: label from bedSummary');
+
+// All three tools populated → merged + sorted by ts desc
+sandbox.localStorage.setItem('history_composite', JSON.stringify([
+  { ts: 3000, params: { 'st-dose': '50', 'pv-dose': '60' } }
+]));
+sandbox.localStorage.setItem('history_rert', JSON.stringify([
+  { ts: 1500, params: { 'pr-fx': '25', 'pr-mo': '18' } }
+]));
+var recentsAll = getRecentAcrossTools.call(sandbox, 3);
+assertEqual(recentsAll.length, 3, 'getRecentAcrossTools: three tools merged → 3');
+assertEqual(recentsAll[0].tool, 'composite', 'getRecentAcrossTools: composite ts=3000 is newest');
+assertEqual(recentsAll[1].tool, 'bed',       'getRecentAcrossTools: bed ts=2000 second');
+assertEqual(recentsAll[2].tool, 'rert',      'getRecentAcrossTools: rert ts=1500 third');
+
+// Default limit = 3 (slices when more entries exist)
+sandbox.localStorage.setItem('history_bed', JSON.stringify([
+  { ts: 2000, params: { 'bd-dose': '60', 'bd-fx': '30' } },
+  { ts: 1000, params: { 'bd-dose': '70', 'bd-fx': '35' } },
+  { ts: 500,  params: { 'bd-dose': '80', 'bd-fx': '40' } }
+]));
+var recentsDefault = getRecentAcrossTools.call(sandbox); // no limit arg
+assertEqual(recentsDefault.length, 3, 'getRecentAcrossTools: default limit = 3');
+
+// Defensive filter: entries missing ts or params are dropped, not rendered
+sandbox.localStorage.setItem('history_bed', JSON.stringify([
+  { ts: 2000, params: { 'bd-dose': '60', 'bd-fx': '30' } }, // good
+  { ts: 'not-a-number', params: { 'bd-dose': '99' } },      // bad ts
+  { ts: 1000 },                                             // missing params
+  { params: { 'bd-dose': '99' } }                           // missing ts
+]));
+sandbox.localStorage.removeItem('history_composite');
+sandbox.localStorage.removeItem('history_rert');
+var recentsFiltered = getRecentAcrossTools.call(sandbox, 5);
+assertEqual(recentsFiltered.length, 1,
+  'getRecentAcrossTools: malformed entries filtered, only the well-formed one kept');
+assertEqual(recentsFiltered[0].params['bd-dose'], '60',
+  'getRecentAcrossTools: kept entry has correct payload');
+
+sandbox.localStorage.clear();
 
 // ============================================================
 // TESTS: clipboard.js — copyToClipboard exists

--- a/url-state.js
+++ b/url-state.js
@@ -40,6 +40,25 @@ function serializeToUrl(inputIds) {
   return window.location.pathname + '?' + params.toString();
 }
 
+// Build a calculator URL from a target path + a params object.
+// Used by the hub's recents row: serializeToUrl reads from the current DOM,
+// which is unusable from the hub. buildToolUrl takes any { inputId: value }
+// shape and produces a URL the target page's parseUrlParams can consume.
+// Empty-string and null values are skipped, matching serializeToUrl behavior.
+function buildToolUrl(toolPath, params) {
+  var sp = new URLSearchParams();
+  if (params) {
+    Object.keys(params).forEach(function (k) {
+      var v = params[k];
+      if (v !== '' && v !== null && v !== undefined) {
+        sp.set(k, v);
+      }
+    });
+  }
+  var qs = sp.toString();
+  return qs ? toolPath + '?' + qs : toolPath;
+}
+
 function initUrlParams(inputIds, updateFn) {
   var params = parseUrlParams(inputIds);
   if (Object.keys(params).length > 0) {


### PR DESCRIPTION
## Summary

Replaces `index.html` — was the ICD-10 search (loaded 9 MB `icd10.xml` via XHR on every cold pageload) — with a 6-tile launcher hub of the site's calculators, plus a recents row pulled from localStorage history of BED + Composite + ReRT.

**User-visible changes**
- Cold pageload at `/` no longer fetches `icd10.xml` (~9 MB) or `script.js`. LCP should drop dramatically per Lighthouse.
- Returning rad onc clinicians see their last 1–3 calculations as one-click pills above the tile grid. Click a pill → calculator opens prefilled and rendered.
- Six tiles in canonical order: BED, ReRT, Composite, Constraints, PSA, ICD Search.
- Below 900 px the grid switches to 2 columns and the pill tap target bumps to 44 px (matches the existing FINDING-001 standard).
- All existing nav links unchanged; brand mark serves as Home affordance.

**ICD migration**
- ICD-10 search moves to `/icd.html`. Same behavior, same 9 MB load — but only when the user actually navigates there.
- Every page's "ICD-10 Search" nav link updated to point to `icd.html`. Brand mark on every page stays pointing at `/`.

**Refactors mirroring earlier review findings**
- `bedSummary` / `compositeSummary` / `rertSummary` become the single source of truth in `history.js`. `bed.js:88` and `composite.js:143` now call them instead of duplicating the lambda inline. Mirrors the F5 finding from /plan-eng-review.
- `getRecentAcrossTools` defensively filters localStorage entries missing `ts` or `params` (F6 finding).
- `--text-secondary` bumped `#a0a0a8` → `#b0b0b8` so 13 px body text on `--bg-card` crosses WCAG AA (≈4.4:1 → ≈5.0:1).

**ReRT history wiring (new in this PR)**
- `rert.js` now calls `saveToHistory` + `renderHistory` on `change` events for `pr-fx`, `pr-ab`, `pr-mo`, `custom-fx`.
- `rert.html` gets a `<details class="history-section">` container matching the bed/composite pattern.
- **Known limitation:** OAR-checkbox selection is not in `RERT_INPUT_IDS` — recents restore the numeric inputs; users re-tick OARs. Documented in the design doc.

**Plumbing**
- `url-state.js` gains `buildToolUrl(toolPath, params)` because the existing `serializeToUrl` reads from the current DOM and is unusable from the hub.
- `sw.js` `CACHE_VERSION` v7-2026-05-29 → v8-2026-05-30. `icd.html` added to `REQUIRED_PRECACHE`. `script.js` stays (still used by `icd.html`).
- `TODOS.md` cleanup: removed stale "Test runner is broken" entry (`node tests.js` runs clean now). Added new TODO to formalize the de facto design system as `DESIGN.md` via `/design-consultation`.
- Hub markup uses class composition `<a class="bed-card hub-tile">` so no `.bed-card` CSS rules are duplicated.

## Test Coverage

`node tests.js` — **271 passing, 0 failures** (was 234; +37 new assertions). New sections:

- `=== url-state.js: buildToolUrl ===` — empty params, typical use, skip-empty-string/null/undefined, **round-trip via parseUrlParams**
- `=== history.js: bedSummary ===` — both present, missing dose, missing fx, empty params
- `=== history.js: compositeSummary ===` — same four shapes
- `=== history.js: rertSummary ===` — same four shapes
- `=== history.js: getRecentAcrossTools ===` — empty localStorage, single-tool, three-tool merge, default limit, **defensive filter on malformed entries**

All four new pure functions (`getRecentAcrossTools`, `bedSummary`, `compositeSummary`, `rertSummary`, plus `buildToolUrl`) have unit coverage. Markup-only changes (hub HTML, nav-href edits, CSS, sw.js bump) are covered by the manual QA checklist below.

## Pre-Landing Review

Three reviews on the same commit prior to this push:

- `/plan-eng-review` — 7 issues, all resolved. Cross-model Codex outside voice ran (F1 refuted, F4 declined, F5 + F6 patched).
- `/plan-design-review` — 8 design decisions made (mockup A approved as `~/.gstack/projects/nb2276-OncologyToolkit/designs/hub-landing-20260529/hub-mockup-A.html`). Score 6/10 → 9/10.
- Inline adversarial scan during /ship — no stray `console.log` / `debugger` / `localhost`. Diff is purely static HTML/CSS/JS — no SQL, no LLM trust boundaries to violate.

## Design Review

Lite check during /ship — no new findings on top of `/plan-design-review`. Mockup A captures the calm-clinical type-first aesthetic; no purple gradients, no icons-in-colored-circles, no centered-everything, no AI-slop hero copy. The 3-column tile grid is differentiated from generic SaaS by typographic-first content (no icons, real product taglines, restrained accent).

## Plan Completion

All 13 implementation tasks from `/plan-eng-review` (7) and `/plan-design-review` (6) completed in this branch. Plan: `~/.gstack/projects/nb2276-OncologyToolkit/nboehling-main-design-20260529-201308.md`.

## Manual QA (before merge)

- [ ] Hub at `/`: tile grid renders, 6 tiles in 3-col on desktop / 2-col below 900 px.
- [ ] Returning user: do a BED calc → return to `/` → recents pill appears → click → `bed.html?bd-dose=…` opens prefilled and rendered.
- [ ] First-time user (clear localStorage): no `.hub-recents` block in the DOM.
- [ ] Each tile click routes to its `.html` page.
- [ ] `/icd.html`: ICD-10 search works identically to the old `/`. All ~150 result types reachable via the radio filters.
- [ ] Every page's "ICD-10 Search" nav link routes to `/icd.html`; `.active` state highlights on `icd.html`.
- [ ] Mobile 390 × 844 (iPhone Safari): recents row + first row of tiles above the fold; pill tap target ≥ 44 px tall.
- [ ] Both dark and light themes look right.
- [ ] DevTools Network panel on `/` cold load: zero requests for `icd10.xml`, zero requests for `script.js`. **This is the primary perf win.**
- [ ] PWA: install, kill, relaunch → hub opens at `/`.
- [ ] Verify `--text-secondary` bump doesn't wash out the helper/hint text on calculator pages.
- [ ] Shortcut `/` on the hub no-ops gracefully (no console error).

## Documentation

- `CLAUDE.md` — Pages table updated (`index.html` is now the hub; new `icd.html` row). JS modules section describes the shared summary functions + `getRecentAcrossTools` + `buildToolUrl`. CSS section mentions section 21 and the 900 px breakpoint convention.
- `README.md` — Tools section reordered to match the hub tile order. Added a "hub" description at the top and the missing Constraints section. Added "Recents on the hub" feature callout.
- `TODOS.md` — removed stale broken-test-runner entry, added DESIGN.md formalization follow-up.

## Test plan

- [x] `node tests.js` exits 0 with **271 passing, 0 failed**
- [x] Branch merged with `origin/main` (already up to date)
- [x] CACHE_VERSION bumped to `v8-2026-05-30`
- [x] `icd.html` present in `REQUIRED_PRECACHE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)