### PR TITLE
fix(pwa): auto-reload on SW controllerchange to heal stale-asset mid-load

### DIFF
--- a/pwa.js
+++ b/pwa.js
@@ -1,5 +1,25 @@
 // Service worker registration. Loaded by every page after main scripts.
+//
+// Why the controllerchange reload:
+//   The SW serves assets cache-first (style.css, *.js) but HTML
+//   network-first. When a new SW activates mid-pageload via skipWaiting
+//   + clients.claim, the current DOM has already painted with the OLD
+//   cache's assets — so a structural change (new HTML referencing new
+//   CSS class names, new JS function names) renders unstyled until the
+//   user reloads a second time. Listening for `controllerchange` and
+//   reloading once auto-heals that mismatch.
+//
+//   The `refreshing` flag guards against any chance of a loop within a
+//   single page load. On the reload triggered by this handler, the new
+//   page starts already controlled by the new SW, so `controllerchange`
+//   does not fire again.
 if ('serviceWorker' in navigator) {
+  var refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', function () {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
   window.addEventListener('load', function () {
     navigator.serviceWorker.register('/sw.js').catch(function () {
       // Registration failures are non-fatal — the site works fine without offline support.

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v9-2026-05-30';
+var CACHE_VERSION = 'v10-2026-05-30';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
## Why

PR #11 added \`skipWaiting()\` + \`clients.claim()\` so a new SW activates immediately. That handles half the stale-asset bug — new SW takes control instead of waiting for a full close-and-reopen. **It does not handle the other half:** the current page has already painted with the OLD cache's assets BEFORE the controller switch happens.

Lifecycle on a reload during a structural deploy:
1. Reload fires → request goes to OLD active SW
2. OLD SW serves OLD \`/style.css\` + OLD \`/history.js\` from OLD cache (cache-first, by design)
3. Page paints with old assets → looks broken (the hub renders unstyled)
4. \`window 'load'\` fires → \`pwa.js\` calls \`register('/sw.js')\`
5. Browser byte-diffs \`sw.js\` → starts new SW install
6. New SW completes → \`skipWaiting()\` → activates → \`clients.claim()\`
7. \`controllerchange\` event fires on \`navigator.serviceWorker\`
8. ❌ Nothing listens for it — page stays broken until manual reload

## Fix

\`pwa.js\` now listens for \`controllerchange\` and reloads once. A \`refreshing\` flag guards against any loop within a single page load. The reloaded page starts already controlled by the new SW, gets fresh assets from the new cache, and renders correctly.

\`CACHE_VERSION\` v9 → v10 so existing v9 tabs detect the new \`sw.js\` bytes and trigger the install/activate flow (which is what makes the new \`pwa.js\` actually take effect for already-installed PWA users).

## Test plan

- [x] \`node --check pwa.js\` — syntax OK
- [x] \`node --check sw.js\` — syntax OK
- [x] \`node tests.js\` — 271 passing, 0 failed
- [ ] **After merge + deploy:** existing-PWA user reloads → sees a brief flash of unstyled content → page auto-reloads once within ~1 second → hub renders correctly. No hard-reload needed.
- [ ] DevTools → Application → Service Workers: shows \`v10-2026-05-30\` active. Only one SW. No "waiting" SW.

## Trade-off

The auto-reload causes a single extra reload during SW updates. Trade-off: one ~250 ms flicker vs the current "render broken, user notices, user manually reloads, finally sees correct page." This pattern is what every major PWA does (the workbox \`controllerchange\` cookbook entry is the canonical reference). Worth the flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)