### PR TITLE
fix(hub): color: inherit on .hub-tile and .hub-recent-pill

### DIFF
--- a/style.css
+++ b/style.css
@@ -2462,6 +2462,11 @@ details[open].rert-oar-picker .rert-picker-chevron {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
   text-decoration: none;
+  /* Override the browser's default <a> color so any direct text in this
+     element inherits from the body instead of rendering as link blue.
+     The named child spans (.hub-recent-tool, -summary) set their own
+     colors regardless, but this keeps the element honest. */
+  color: inherit;
   transition: border-color var(--transition-med), background var(--transition-med);
   cursor: pointer;
 }
@@ -2500,6 +2505,10 @@ details[open].rert-oar-picker .rert-picker-chevron {
   padding: 22px 24px;
   min-height: 100px;
   text-decoration: none;
+  /* Override the browser's default <a> color. Children (.hub-tile-name,
+     .hub-tile-tagline) set their own colors, but this keeps the link
+     element from rendering any direct text as blue. */
+  color: inherit;
   /* class composition: background/border/radius/shadow from .bed-card */
 }
 .hub-tile:hover {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v10-2026-05-30';
+var CACHE_VERSION = 'v11-2026-05-30';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
ISSUE-001 from yesterday's /qa run. Both `.hub-tile` and `.hub-recent-pill` are `<a>` elements that didn't set an explicit `color`, so they inherited the browser default link blue (`rgb(0, 0, 238)`). The named child spans render their own colors so nothing actually shows up blue — but it's a one-line cleanup.

Bumped `CACHE_VERSION` to `v11-2026-05-30` so existing v10 PWA users pick up the fix on next page load.

## Test plan
- [x] `node --check sw.js` — syntax OK
- [x] `node tests.js` — 271 passing, 0 failed
- [x] DevTools computed color on `.hub-tile` and `.hub-recent-pill` should now be `rgb(236, 236, 240)` (--text-primary in dark mode) instead of `rgb(0, 0, 238)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)