### PR TITLE
feat(validation): require whole-number fractions

### DIFF
--- a/bed.js
+++ b/bed.js
@@ -7,13 +7,14 @@ var BED_INPUT_IDS = ['bd-dose', 'bd-fx', 'ab1', 'ab2', 'ab3', 'arb-fx'];
 
 // Input validation ranges. Max fractions is 80 — beyond that is essentially
 // always a fat-finger error (max real-world regimen we'd expect is ~45 fx).
+// `integer: true` on fractions because you can't deliver 25.5 sessions.
 var BED_RANGES = {
   'bd-dose': { min: 0.1, max: 200, label: 'Typical: 1–80 Gy' },
-  'bd-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' },
+  'bd-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true },
   'ab1':     { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
   'ab2':     { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
   'ab3':     { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
-  'arb-fx':  { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' }
+  'arb-fx':  { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true }
 };
 
 function validateInputs() {

--- a/composite.js
+++ b/composite.js
@@ -5,15 +5,16 @@
 var COMP_INPUT_IDS = ['st-dose', 'st-fx', 'st-ab', 'pv-dose', 'pv-fx', 'pv-tdf', 'rem-fx'];
 
 // Fraction max bumped to 80 to match BED page — anything higher is essentially
-// always a fat-finger error. applyRangeWarning lives in validate.js.
+// always a fat-finger error. `integer: true` on fractions because you can't
+// deliver a fractional treatment session. applyRangeWarning lives in validate.js.
 var COMP_RANGES = {
   'st-dose': { min: 0.1, max: 200, label: 'Typical: 1–80 Gy' },
-  'st-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' },
+  'st-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true },
   'st-ab':   { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
   'pv-dose': { min: 0.1, max: 200, label: 'Typical: 1–80 Gy' },
-  'pv-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' },
+  'pv-fx':   { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true },
   'pv-tdf':  { min: 0,   max: 1,   label: 'Range: 0–1' },
-  'rem-fx':  { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' }
+  'rem-fx':  { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true }
 };
 
 function validateInputs() {

--- a/rert.js
+++ b/rert.js
@@ -87,10 +87,10 @@ function getTimeBucketLabel(months) {
 // for Gy vs cc).
 // ============================================================
 var RERT_RANGES = {
-  'pr-fx':     { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' },
+  'pr-fx':     { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true },
   'pr-ab':     { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
   'pr-mo':     { min: 0,   max: 600, label: 'Typical: 0–120 months' },
-  'custom-fx': { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)' }
+  'custom-fx': { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true }
 };
 
 var OAR_DOSE_RANGE_GY = { min: 0, max: 200,  label: 'Typical: 1–80 Gy' };

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v12-2026-06-08';
+var CACHE_VERSION = 'v13-2026-06-08';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.

--- a/tests.js
+++ b/tests.js
@@ -886,8 +886,9 @@ assert(typeof copyToClipboard === 'function', 'copyToClipboard is a function');
 
 section('=== validate.js: classifyRange ===');
 
-var fxRange   = { min: 1,   max: 80, label: 'Typical: 1–45 fx (>80 is rare)' };
-var doseRange = { min: 0.1, max: 200, label: 'Typical: 1–80 Gy' };
+var fxRange      = { min: 1,   max: 80, label: 'Typical: 1–45 fx (>80 is rare)', integer: true };
+var fxRangeNoInt = { min: 1,   max: 80, label: 'Typical: 1–45 fx (>80 is rare)' };
+var doseRange    = { min: 0.1, max: 200, label: 'Typical: 1–80 Gy' };
 
 assertEqual(classifyRange(NaN, fxRange),    'ok',        'NaN → ok (blank input, no warning)');
 assertEqual(classifyRange(-1,  fxRange),    'negative',  '-1 fx → negative');
@@ -902,6 +903,16 @@ assertEqual(classifyRange(0.1, doseRange),  'ok',        '0.1 Gy → ok (at min)
 assertEqual(classifyRange(80,  doseRange),  'ok',        '80 Gy → ok (typical max)');
 assertEqual(classifyRange(200, doseRange),  'ok',        '200 Gy → ok (at max)');
 assertEqual(classifyRange(201, doseRange),  'high',      '201 Gy → high');
+
+// Integer enforcement — fractions must be whole numbers
+assertEqual(classifyRange(25.5,  fxRange),      'non-integer', '25.5 fx → non-integer (decimal not allowed)');
+assertEqual(classifyRange(1.5,   fxRange),      'non-integer', '1.5 fx → non-integer');
+assertEqual(classifyRange(0.5,   fxRange),      'non-integer', '0.5 fx → non-integer (precedes the low check)');
+assertEqual(classifyRange(25,    fxRange),      'ok',          '25 fx → ok (clean integer)');
+assertEqual(classifyRange(25.0,  fxRange),      'ok',          '25.0 fx → ok (parseFloat treats as 25)');
+assertEqual(classifyRange(25.5,  fxRangeNoInt), 'ok',          '25.5 fx with no integer flag → ok');
+assertEqual(classifyRange(2.75,  doseRange),    'ok',          '2.75 Gy → ok (dose allows decimals)');
+assertEqual(classifyRange(-1.5,  fxRange),      'negative',    '-1.5 → negative wins over non-integer');
 
 section('=== validate.js: RERT_RANGES wiring ===');
 
@@ -946,6 +957,19 @@ var inputBlank = { value: '' };
 var warnBlank  = makeWarn();
 applyRangeWarning(inputBlank, warnBlank, fxRange);
 assertEqual(warnBlank.style.display, 'none', 'blank input → no warning');
+
+// Integer fraction enforcement at DOM level
+var inputDecimal = { value: '25.5' };
+var warnDecimal  = makeWarn();
+applyRangeWarning(inputDecimal, warnDecimal, fxRange);
+assertEqual(warnDecimal.style.display, 'block', '25.5 fx triggers warning');
+assert(warnDecimal.classList.contains('input-range-error'), '25.5 fx gets red error class');
+assert(warnDecimal.textContent.indexOf('whole number') !== -1, 'non-integer message mentions "whole number"');
+
+var inputDose = { value: '2.75' };
+var warnDose  = makeWarn();
+applyRangeWarning(inputDose, warnDose, doseRange);
+assertEqual(warnDose.style.display, 'none', '2.75 Gy (dose, no integer flag) → no warning');
 
 // ============================================================
 // Summary

--- a/validate.js
+++ b/validate.js
@@ -1,14 +1,17 @@
 // Shared input-range warning helper used by bed.js / composite.js / rert.js.
 // Goal: prevent fat-finger errors on dose / fraction inputs.
 //
-// Three states:
-//   - val < 0           → red "Cannot be negative" (.input-range-error)
-//   - val outside range → yellow typical-range hint (existing behavior)
-//   - val valid or NaN  → no warning
+// Four states:
+//   - val < 0                                → red "Cannot be negative"
+//   - range.integer && !Number.isInteger(val) → red "Must be a whole number"
+//   - val outside range                      → yellow typical-range hint
+//   - val valid or NaN                       → no warning
 //
-// `range` is { min, max, label }. `label` is shown for out-of-range
-// (non-negative) values. Negatives always show the same hard-stop message
-// because they're never clinically meaningful.
+// `range` is { min, max, label, integer? }. `label` is shown for out-of-range
+// (non-negative, integer-valid) values. Negatives and non-integer fractions
+// always show their hard-stop messages because they're physically impossible:
+// you can't deliver -5 sessions, and you can't deliver 25.5 sessions either —
+// fraction count is the number of times the patient comes to the linac.
 
 function applyRangeWarning(inputEl, warnEl, range) {
   if (!inputEl || !warnEl) return;
@@ -28,6 +31,13 @@ function applyRangeWarning(inputEl, warnEl, range) {
     return;
   }
 
+  if (range.integer && !Number.isInteger(val)) {
+    warnEl.textContent = '⚠ Must be a whole number';
+    warnEl.style.display = 'block';
+    warnEl.classList.add('input-range-error');
+    return;
+  }
+
   if (val < range.min || val > range.max) {
     warnEl.textContent = range.label;
     warnEl.style.display = 'block';
@@ -41,13 +51,15 @@ function applyRangeWarning(inputEl, warnEl, range) {
 }
 
 // Classify a value against a range. Returned for testability without DOM.
-//   'ok'       — in range or NaN
-//   'negative' — val < 0
-//   'low'      — 0 <= val < min
-//   'high'     — val > max
+//   'ok'           — in range or NaN
+//   'negative'     — val < 0
+//   'non-integer'  — range.integer && !Number.isInteger(val) (and val >= 0)
+//   'low'          — 0 <= val < min (and integer if required)
+//   'high'         — val > max (and integer if required)
 function classifyRange(val, range) {
   if (isNaN(val)) return 'ok';
   if (val < 0) return 'negative';
+  if (range.integer && !Number.isInteger(val)) return 'non-integer';
   if (val < range.min) return 'low';
   if (val > range.max) return 'high';
   return 'ok';


### PR DESCRIPTION
## Summary

Follow-up to #14 (fat-finger guardrails). Codex's adversarial review on that PR flagged that `25.5` fractions was silently accepted. You can't deliver half a treatment session — fraction count is the number of times the patient comes to the linac, so this is physically impossible.

Now every fraction input rejects non-integers with a red **"⚠ Must be a whole number"** error, matching the visual treatment of the existing "Cannot be negative" hard-stop.

## Behavior

| Input | Field | Before | After |
|---|---|---|---|
| `25.5` | `bd-fx` (fractions) | silently accepted | red "Must be a whole number" |
| `2.75` | `bd-dose` (dose Gy) | accepted ✓ | accepted ✓ (decimals valid for dose) |
| `-1.5` | `bd-fx` | red "Cannot be negative" | red "Cannot be negative" (negative still wins) |
| `25.0` | `bd-fx` | accepted ✓ | accepted ✓ (JS treats as `25`) |
| `25` | `bd-fx` | accepted ✓ | accepted ✓ |

## Implementation

- `validate.js`: new `'non-integer'` classifier state. Range entries opt in via `integer: true`. Check order: `negative > non-integer > range`, so a `-1.5` shows the negative message (the more urgent issue).
- Applied `integer: true` to all seven fraction ranges: `bd-fx`, `arb-fx` (BED); `st-fx`, `pv-fx`, `rem-fx` (Composite); `pr-fx`, `custom-fx` (ReRT).
- Dose / α/β / TDF / months ranges unchanged — decimals are valid there (2.75 Gy/fx, α/β = 2.5, TDF = 0.05).

## Test Coverage

- 297 → 309 (+12 new assertions).
- New `classifyRange` tests: `25.5` / `1.5` / `0.5` → non-integer; `25` / `25.0` → ok; `25.5` without integer flag → ok; `2.75` Gy (dose) → ok; `-1.5` → negative (precedence test).
- New DOM-level `applyRangeWarning` tests confirm the red `.input-range-error` class is applied and the message contains "whole number".

## PWA

- `CACHE_VERSION` v12 → v13 (precached JS changed).

## Test plan

- [x] `node tests.js` → 309 passed, 0 failed.
- [x] Manual: type `25.5` in `bd-fx` → red "Must be a whole number".
- [x] Manual: type `2.75` in `bd-dose` → no warning (decimals valid for dose).
- [x] Manual: type `-1.5` in `bd-fx` → red "Cannot be negative" (not "whole number" — negative takes precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)