### PR TITLE
feat(validation): require whole-number months in ReRT

### DIFF
--- a/rert.js
+++ b/rert.js
@@ -89,7 +89,7 @@ function getTimeBucketLabel(months) {
 var RERT_RANGES = {
   'pr-fx':     { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true },
   'pr-ab':     { min: 0.1, max: 30,  label: 'Typical: 1–20 Gy' },
-  'pr-mo':     { min: 0,   max: 600, label: 'Typical: 0–120 months' },
+  'pr-mo':     { min: 0,   max: 600, label: 'Typical: 0–120 months', integer: true },
   'custom-fx': { min: 1,   max: 80,  label: 'Typical: 1–45 fx (>80 is rare)', integer: true }
 };
 

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v13-2026-06-08';
+var CACHE_VERSION = 'v14-2026-06-08';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.

--- a/tests.js
+++ b/tests.js
@@ -918,8 +918,13 @@ section('=== validate.js: RERT_RANGES wiring ===');
 
 assert(RERT_RANGES['pr-fx'].max === 80,        'pr-fx max is 80');
 assert(RERT_RANGES['pr-ab'].max === 30,        'pr-ab max is 30');
+assert(!RERT_RANGES['pr-ab'].integer,          'pr-ab is NOT integer (α/β commonly 1.5, 2.5)');
 assert(RERT_RANGES['pr-mo'].min === 0,         'pr-mo min is 0 (no negative months)');
+assert(RERT_RANGES['pr-mo'].integer === true,  'pr-mo is integer (clinical months are whole)');
 assert(RERT_RANGES['custom-fx'].max === 80,    'custom-fx max is 80');
+assertEqual(classifyRange(6.5, RERT_RANGES['pr-mo']), 'non-integer', '6.5 months → non-integer');
+assertEqual(classifyRange(6,   RERT_RANGES['pr-mo']), 'ok',          '6 months → ok');
+assertEqual(classifyRange(2.5, RERT_RANGES['pr-ab']), 'ok',          '2.5 α/β → ok (decimals allowed)');
 assert(OAR_DOSE_RANGE_GY.max === 200,          'OAR Gy dose max is 200');
 assert(OAR_DOSE_RANGE_CC.max === 5000,         'OAR cc volume max is 5000');
 


### PR DESCRIPTION
## Summary

Extends the integer-fraction enforcement from #15 to **months since prior RT** (`pr-mo` on the ReRT page). TRF bucket boundaries are integer months and clinicians don't say "6.5 months since prior RT" in practice, so a decimal there is a typo.

**Scope decision (asked, confirmed):** α/β fields are **not** integer-enforced. The textbook prostate α/β is 1.5 and the ReRT default for `pr-ab` is 2.5 — enforcing integer there would flag valid radiobiology values.

| Input | Field | Before | After |
|---|---|---|---|
| `6.5` | `pr-mo` (months) | accepted | red "⚠ Must be a whole number" |
| `12` | `pr-mo` | accepted ✓ | accepted ✓ |
| `2.5` | `pr-ab` (α/β) | accepted ✓ | accepted ✓ (decimals still valid) |
| `1.5` | `pr-ab` (prostate α/β) | accepted ✓ | accepted ✓ |

## Tests

309 → 314 (+5). New assertions:
- `classifyRange(6.5, RERT_RANGES['pr-mo'])` → `non-integer`
- `classifyRange(6, RERT_RANGES['pr-mo'])` → `ok`
- `classifyRange(2.5, RERT_RANGES['pr-ab'])` → `ok` (decimals still allowed)
- Meta: `RERT_RANGES['pr-mo'].integer === true` and `!RERT_RANGES['pr-ab'].integer` — a future regression flipping either flag fails loudly.

## PWA

`CACHE_VERSION` v13 → v14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)