### PR TITLE
PSA: add spacing above the Recent Calculations panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -713,6 +713,14 @@ nav.nav-open .nav-toggle span:nth-child(3) {
   margin: -8px 0 20px;
 }
 
+/* Separate the Recent Calculations panel from the chart/controls above it.
+   Scoped to the PSA column so the shared .history-section spacing on
+   bed/composite is untouched. Must exceed the chart-section's 28px
+   bottom margin (adjacent block margins collapse to the larger of the two). */
+.psa-col-right .history-section {
+  margin-top: 44px;
+}
+
 /* White background mode for PSA results */
 .psa-white-mode {
   background: #ffffff;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // The browser detects a new SW only if sw.js bytes differ. If you ship
 // new HTML/CSS/JS without bumping, users may serve new HTML against
 // stale precached JS until the next bump.
-var CACHE_VERSION = 'v17-2026-06-11';
+var CACHE_VERSION = 'v18-2026-06-11';
 var STATIC_CACHE = 'ot-static-' + CACHE_VERSION;
 // DATA_CACHE survives version bumps so the 9 MB ICD-10 XML doesn't
 // re-download on every deploy.


### PR DESCRIPTION
The Recent Calculations history panel sat only 28px below the chart controls, reading as crowded.

Adds a 44px top margin scoped to `.psa-col-right .history-section` (must exceed the chart-section's 28px bottom margin, since adjacent block margins collapse to the larger). Scoped to the PSA column so the shared `.history-section` spacing on BED/Composite is untouched. `CACHE_VERSION` bumped v17 → v18.

Verified in-browser: rendered gap is now 44px. Tests 384/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)